### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,7 +7,7 @@
 #######################################
 
 WiFiManager	KEYWORD1
-WiFiManagerParameter KEYWORD1
+WiFiManagerParameter	KEYWORD1
 
 
 #######################################
@@ -16,28 +16,28 @@ WiFiManagerParameter KEYWORD1
 autoConnect	KEYWORD2
 getSSID	KEYWORD2
 getPassword	KEYWORD2
-getConfigPortalSSID KEYWORD2
+getConfigPortalSSID	KEYWORD2
 resetSettings	KEYWORD2
 setConfigPortalTimeout	KEYWORD2
-setConnectTimeout KEYWORD2
+setConnectTimeout	KEYWORD2
 setDebugOutput	KEYWORD2
-setMinimumSignalQuality KEYWORD2
+setMinimumSignalQuality	KEYWORD2
 setAPStaticIPConfig	KEYWORD2
-setSTAStaticIPConfig KEYWORD2
+setSTAStaticIPConfig	KEYWORD2
 setAPCallback	KEYWORD2
-setSaveConfigCallback KEYWORD2
-addParameter KEYWORD2
-getID KEYWORD2
-getValue KEYWORD2
-getPlaceholder KEYWORD2
-getValueLength KEYWORD2
-emptyGear KEYWORD2
-setEEPROMOffset KEYWORD2
-setEEPROMOffset KEYWORD2
-AppID KEYWORD2
-Key KEYWORD2
-Secret KEYWORD2
-Alias KEYWORD2
+setSaveConfigCallback	KEYWORD2
+addParameter	KEYWORD2
+getID	KEYWORD2
+getValue	KEYWORD2
+getPlaceholder	KEYWORD2
+getValueLength	KEYWORD2
+emptyGear	KEYWORD2
+setEEPROMOffset	KEYWORD2
+setEEPROMOffset	KEYWORD2
+AppID	KEYWORD2
+Key	KEYWORD2
+Secret	KEYWORD2
+Alias	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords